### PR TITLE
Added Get-GCLabelIDFromFilePrivate

### DIFF
--- a/GuardiCoreHelper/Private/Get-GCLabelIDFromFilePrivate.ps1
+++ b/GuardiCoreHelper/Private/Get-GCLabelIDFromFilePrivate.ps1
@@ -1,0 +1,14 @@
+function Get-GCLabelIDFromFilePrivate {
+	param (
+		$Files
+	)
+	
+	$LabelIDs = @()
+	
+	foreach ($File in $Files) {
+		$LabelIDGroup = Import-CSV -Header IP $File | select -ExpandProperty IP
+		$LabelIDs += @(,$LabelIDGroup)
+	}
+	
+	$LabelIDs
+}


### PR DESCRIPTION
allows New-GCPolicy to get label IDs from files and arrange them into a 2d array