### PR TITLE
Updated authentication

### DIFF
--- a/GuardiCoreHelper/Private/Get-GCFlowPrivate.ps1
+++ b/GuardiCoreHelper/Private/Get-GCFlowPrivate.ps1
@@ -19,12 +19,14 @@ function Get-GCFlowPrivate {
 	
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][Int64]$FromTime,
 		[Parameter(Mandatory=$false)][Int64]$ToTime,
 		[Parameter(Mandatory=$false)][Int32]$Limit,
 		[Parameter(Mandatory=$false)][Int32]$Offset
 	)
+	begin {
+		$Key = $global:GCApiKey
+	}
 	process {
 		$Uri = $Key.Uri + "connections?sort=-slot_start_time"
 		

--- a/GuardiCoreHelper/Private/New-GCBulkStaticLabelPrivate.ps1
+++ b/GuardiCoreHelper/Private/New-GCBulkStaticLabelPrivate.ps1
@@ -17,10 +17,11 @@
 #>
 function New-GCBulkStaticLabelPrivate {
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false,ValueFromPipeline=$true)][System.Object[]]$Labels
 	)
 	begin {
+		$Key = $global:GCApiKey
+		
 		$Uri = $Key.Uri + "visibility/labels/bulk"
 	}
 	process {

--- a/GuardiCoreHelper/Public/Get-GCAgent.ps1
+++ b/GuardiCoreHelper/Public/Get-GCAgent.ps1
@@ -19,7 +19,6 @@ function Get-GCAgent {
 
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][System.String]$Version,
 		[Parameter(Mandatory=$false)][System.String]$Kernel,
 		[Parameter(Mandatory=$false)][ValidateSet("Unknown","Windows","Linux")][System.String]$OS,
@@ -36,6 +35,7 @@ function Get-GCAgent {
 		[Parameter(Mandatory=$false)][ValidateRange(0,500000)][Int32]$Offset
 	)
 	begin {
+		$Key = $global:GCApiKey
 		$Uri = $Key.Uri + "agents?"
 		
 		#Building the Uri with given parameters

--- a/GuardiCoreHelper/Public/Get-GCApiKey.ps1
+++ b/GuardiCoreHelper/Public/Get-GCApiKey.ps1
@@ -40,10 +40,9 @@ function Get-GCApiKey {
 		$Token = Invoke-RestMethod -Uri $TempUri -Method "POST" -Body $BodyJson -ContentType "application/json" | Select-Object -ExpandProperty "access_token" | ConvertTo-SecureString -AsPlainText -Force
 	}
 	end {
-		$Key = [PSCustomObject]@{
+		$global:GCApiKey = [PSCustomObject]@{ #Saves the object in a global (session scope) variable called GCApiKey, so other functions don't need a key input.
 			Token = $Token
 			Uri = $Uri
 		}
-		$Key
 	}
 }

--- a/GuardiCoreHelper/Public/Get-GCAsset.ps1
+++ b/GuardiCoreHelper/Public/Get-GCAsset.ps1
@@ -33,7 +33,6 @@ function Get-GCAsset {
 
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false,ValueFromPipeline=$true)][System.String]$Search,
 		[Parameter(Mandatory=$false)][ValidateSet("on","off")][System.String]$Status,
 		[Parameter(Mandatory=$false)][ValidateRange(0,3)][Int32]$Risk,
@@ -41,6 +40,7 @@ function Get-GCAsset {
 		[Parameter(Mandatory=$false)][ValidateRange(0,500000)][Int32]$Offset
 	)
 	process {
+		$Key = $global:GCApiKey
 		$Uri = $Key.Uri + "assets?"
 		
 		#Building the Uri with given parameters

--- a/GuardiCoreHelper/Public/Get-GCFlow.ps1
+++ b/GuardiCoreHelper/Public/Get-GCFlow.ps1
@@ -2,7 +2,6 @@ function Get-GCFlow {
 	
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$true)][DateTime]$StartTime,
 		[Parameter(Mandatory=$true)][DateTime]$EndTime,
 		[Parameter(Mandatory=$true)][ValidateScript({
@@ -15,23 +14,23 @@ function Get-GCFlow {
 			$true
 		})][System.IO.FileInfo]$OutPath
 	)
-
+	
 	#Ensure the out path has no trailing slash
 	if (($OutPath[$OutPath.length-1] -eq "/") -or ($OutPath[$OutPath.length-1] -eq "\")) {
 		$OutPath = $OutPath.SubString(0,$OutPath.length-1)
 	}
-
+	
 	$Start = ConvertTo-GCUnixTime -DateTime $StartTime
 	$End = ConvertTo-GCUnixTime -DateTime $EndTime
-
+	
 	$1Hour = 3600000
 	$Counter = 0
-
+	
 	for ($j = $Start; $j -lt $End+1; $j += $1Hour) { #Start time to end time
 		$FromTime = $Start + ($1Hour * $Counter)
 		$ToTime = $FromTime + $1Hour
 		for ($i = 0;$i -lt 500000; $i += 10000) { #chunks of 10000 for timeouts, maximum of offset = 500000 because of hard limit
-			$Flows = Get-GCFlowPrivate -Key $Key -Offset $i -Limit 10000 -FromTime $FromTime -ToTime $ToTime
+			$Flows = Get-GCFlowPrivate -Offset $i -Limit 10000 -FromTime $FromTime -ToTime $ToTime
 			if ($Flows.count -lt 1) {
 				break
 			}

--- a/GuardiCoreHelper/Public/Get-GCLabel.ps1
+++ b/GuardiCoreHelper/Public/Get-GCLabel.ps1
@@ -19,13 +19,15 @@ function Get-GCLabel {
 	
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][Switch]$FindMatches,
 		[Parameter(Mandatory=$false)][System.String]$LabelKey,
 		[Parameter(Mandatory=$false)][System.String]$LabelValue,
 		[Parameter(Mandatory=$false)][Int32]$Limit,
 		[Parameter(Mandatory=$false)][Int32]$Offset
 	)
+	begin {
+		$Key = $global:GCApiKey
+	}
 	process {
 		$Uri = $Key.Uri + "visibility/labels?"
 		

--- a/GuardiCoreHelper/Public/Get-GCPolicy.ps1
+++ b/GuardiCoreHelper/Public/Get-GCPolicy.ps1
@@ -4,7 +4,6 @@ function Get-GCPolicy {
 
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][ValidateSet("TCP","UDP")][System.Array]$Protocols = @("TCP","UDP"),
 		[Parameter(Mandatory=$true)][ValidateSet("allow","alert","block","block_and_alert")][System.String]$Action,
 		[Parameter(Mandatory=$false)][ValidateRange(1,65535)][System.Array]$Ports,
@@ -53,6 +52,8 @@ function Get-GCPolicy {
 		[Parameter(Mandatory=$false)][Switch]$DestinationInternet,
 		[Parameter(Mandatory=$false)][Switch]$AnySideInternet
 	)
+	
+	$Key = $global:GCApiKey
 	
 	if ($SourceLabelFile) {
 		$SourceLabelIDs = Get-GCLabelIDFromFilePrivate -File $SourceLabelFile

--- a/GuardiCoreHelper/Public/New-GCBulkStaticLabel.ps1
+++ b/GuardiCoreHelper/Public/New-GCBulkStaticLabel.ps1
@@ -2,7 +2,6 @@ function New-GCBulkStaticLabel {
 
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$true)][ValidateScript({
 			if (-not ($_ | Test-Path)) {
 				throw "File or folder does not exist."
@@ -13,9 +12,9 @@ function New-GCBulkStaticLabel {
 			$true
 		})][System.IO.FileInfo]$Path
 	)
-
+	$Key = $global:GCApiKey
 	#Getting all the active assets
-	$Assets = Get-GCAsset -Key $Key -Limit 100
+	$Assets = Get-GCAsset -Limit 100
 
 	$Sheet = Import-CSV $Path | Sort
 
@@ -47,5 +46,5 @@ function New-GCBulkStaticLabel {
 	}
 
 	#Now we can make the API call
-	$Labels | New-GCBulkStaticLabelPrivate -Key $Key
+	$Labels | New-GCBulkStaticLabelPrivate
 }

--- a/GuardiCoreHelper/Public/New-GCDynamicLabel.ps1
+++ b/GuardiCoreHelper/Public/New-GCDynamicLabel.ps1
@@ -1,6 +1,5 @@
 function New-GCDynamicLabel {
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][System.String]$LabelKey,
 		[Parameter(Mandatory=$false)][System.String]$LabelValue,
 		[Parameter(Mandatory=$false)][System.String]$Argument,
@@ -8,8 +7,9 @@ function New-GCDynamicLabel {
 		[Parameter(Mandatory=$false)][ValidateSet("STARTSWITH","ENDSWITH","EQUALS","CONTAINS","SUBNET","WILDCARDS")][System.String]$Operation,
 		[Parameter(Mandatory=$false,ValueFromPipeline = $true)][PSCustomObject]$Criteria
 	)
-	
 	begin {
+		$Key = $global:GCApiKey
+		
 		$Uri = $Key.Uri + "visibility/labels"
 		
 		$Body = [PSCustomObject]@{

--- a/GuardiCoreHelper/Public/New-GCPolicy.ps1
+++ b/GuardiCoreHelper/Public/New-GCPolicy.ps1
@@ -4,7 +4,6 @@ function New-GCPolicy {
 
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][ValidateSet("TCP","UDP")][System.Array]$Protocols = @("TCP","UDP"),
 		[Parameter(Mandatory=$true)][ValidateSet("allow","alert","block","block_and_alert")][System.String]$Action,
 		[Parameter(Mandatory=$false)][ValidateRange(1,65535)][System.Array]$Ports,
@@ -40,6 +39,7 @@ function New-GCPolicy {
 		[Parameter(Mandatory=$false)][Switch]$SourceInternet,
 		[Parameter(Mandatory=$false)][Switch]$DestinationInternet
 	)
+	$Key = $global:GCApiKey
 	
 	if ($SourceLabelFile) {
 		$SourceLabelIDs = Get-GCLabelIDFromFilePrivate -File $SourceLabelFile

--- a/GuardiCoreHelper/Public/New-GCStaticLabel.ps1
+++ b/GuardiCoreHelper/Public/New-GCStaticLabel.ps1
@@ -5,9 +5,6 @@
 .DESCRIPTION
 	Creates a static label with given VMs, specified by unique ID. if the given Key/Value pair already exists, the new VMs are appended to the existing label.
 
-.PARAMETER Key
-	[PSCustomObject] GuardiCore api key.
-
 .PARAMETER Assets
 	[System.Array] Array of GuardiCore asset IDs. Used for static label definitions.
 
@@ -28,12 +25,13 @@ function New-GCStaticLabel {
 
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false,ValueFromPipeline=$true)][System.Array]$AssetIds,
 		[Parameter(Mandatory=$true)][System.String]$LabelKey,
 		[Parameter(Mandatory=$true)][System.String]$LabelValue
 	)
 	begin {
+		$Key = $global:GCApiKey
+		
 		$Uri = $Key.Uri + "assets/labels/" + $LabelKey + "/" + $LabelValue
 		$Body = [PSCustomObject]@{
 			"vms" = @()

--- a/GuardiCoreHelper/Public/Publish-GCPolicy.ps1
+++ b/GuardiCoreHelper/Public/Publish-GCPolicy.ps1
@@ -4,9 +4,9 @@ function Publish-GCPolicy {
 	
 	[cmdletbinding()]
 	param(
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$true)][System.String]$Comments
 	)
+	$Key = $global:GCApiKey
 	
 	$Uri = $Key.Uri + "visibility/policy/revisions"
 	

--- a/GuardiCoreHelper/Public/Remove-GCLabel.ps1
+++ b/GuardiCoreHelper/Public/Remove-GCLabel.ps1
@@ -4,10 +4,10 @@ function Remove-GCLabel {
 	
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false,ValueFromPipeline=$true)][PSCustomObject]$Label
 	)
 	begin {
+		$Key = $global:GCApiKey
 		$Result = @()
 	}
 	process {

--- a/GuardiCoreHelper/Public/Remove-GCPolicy.ps1
+++ b/GuardiCoreHelper/Public/Remove-GCPolicy.ps1
@@ -4,9 +4,9 @@ function Remove-GCPolicy {
 	
 	[cmdletbinding()]
 	param (
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false)][System.String]$PolicyID
 	)
+	$Key = $global:GCApiKey
 	
 	$Uri = $Key.Uri + "visibility/policy/rules/" + $PolicyID
 	

--- a/GuardiCoreHelper/Public/Set-GCLabel.ps1
+++ b/GuardiCoreHelper/Public/Set-GCLabel.ps1
@@ -4,9 +4,9 @@ function Set-GCLabel {
 	
 	[cmdletbinding()]
 	param(
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false,ValueFromPipeline=$true)][PSCustomObject]$Label #Label object as returned from GuardiCore, but with updated values. Accepts the PS object, not JSON data. This allows you to grab a label, change it via powershell methods, and pass it into this function to update it.
 	)
+	$Key = $global:GCApiKey
 	
 	$Uri = $Key.Uri + "visibility/labels/" + $Label.id
 	

--- a/GuardiCoreHelper/Public/Set-GCPolicy.ps1
+++ b/GuardiCoreHelper/Public/Set-GCPolicy.ps1
@@ -4,9 +4,9 @@ function Set-GCPolicy {
 	
 	[cmdletbinding()]
 	param(
-		[Parameter(Mandatory=$true)][PSCustomObject]$Key,
 		[Parameter(Mandatory=$false,ValueFromPipeline=$true)][PSCustomObject]$Policy #Policy object as returned from GuardiCore, but with updated values. Accepts the PS object, not JSON data. This allows you to grab a policy, change it via powershell methods, and pass it into this function to update it.
 	)
+	$Key = $global:GCApiKey
 	
 	$Uri = $Key.Uri + "visibility/policy/rules/" + $Policy.id
 	


### PR DESCRIPTION
Fetching an api key now stores its value in a session-scoped variable called GCApiKey. All of the functions that used to take a -Key parameter now no longer require one; they'll grab it from the global variable.

With pipeline support on its way, I wanted to make it so workflows that would look like this:

Get-GCAsset -Key $Key | New-GCStaticLabel -Key $Key -LabelKey Test -LabelValue Test

Instead look like this:

Get-GCAsset | New-GCStaticLabel -LabelKey Test -LabelValue Test